### PR TITLE
Title: Practical test v2: tasks, validators, and fixes

### DIFF
--- a/app/controllers/practical_tests_controller.rb
+++ b/app/controllers/practical_tests_controller.rb
@@ -1,4 +1,6 @@
 class PracticalTestsController < TestsController
+  skip_before_action :verify_authenticity_token, only: :answer
+
   # POST /practical_tests/:id/start
   def start
     super

--- a/app/validators/change_registrant_with_method_validator.rb
+++ b/app/validators/change_registrant_with_method_validator.rb
@@ -1,0 +1,70 @@
+class ChangeRegistrantWithMethodValidator < BaseTaskValidator
+  def call
+    api = []
+    errors = []
+
+    source_name, target_name = resolve_domains
+    if source_name.blank? || target_name.blank?
+      errors << 'Source or target domain is missing'
+      return failure(api, errors)
+    end
+
+    source = with_audit(api, 'domain_info') { @service.domain_info(name: source_name) }
+    target = with_audit(api, 'domain_info') { @service.domain_info(name: target_name) }
+
+    if source.nil? || source[:success] == false
+      errors << "Source domain #{source_name} not found"
+    end
+    if target.nil? || target[:success] == false
+      errors << "Target domain #{target_name} not found"
+    end
+    return failure(api, errors) unless errors.empty?
+
+    errors.concat(registrant_errors(source, target))
+    errors.concat(method_errors(target))
+
+    return failure(api, errors) unless errors.empty?
+
+    pass(api, { source_domain: source, target_domain: target })
+  end
+
+  private
+
+  def resolve_domains
+    source_tmpl = @config['source_domain'] || ''
+    target_tmpl = @config['target_domain'] || ''
+
+    source_name = Mustache.render(source_tmpl.to_s, @attempt.vars)
+    target_name = Mustache.render(target_tmpl.to_s, @attempt.vars)
+
+    [source_name, target_name]
+  end
+
+  def expected_method
+    (@config['expected_method'] || '').to_s
+  end
+
+  def registrant_errors(source, target)
+    src = source.dig(:registrant, :code)
+    tgt = target.dig(:registrant, :code)
+    errors = []
+
+    errors << 'Source domain registrant missing' if src.blank?
+    errors << 'Target domain registrant missing' if tgt.blank?
+    errors << 'Target registrant does not match source registrant' if src.present? && tgt.present? && src != tgt
+
+    errors
+  end
+
+  def method_errors(target)
+    method = target[:last_registrant_change_method].to_s
+    return [] if expected_method.blank? || method == expected_method
+
+    ["Last registrant change method #{method} does not match expected #{expected_method}"]
+  end
+
+  def api_service_adapter
+    DomainService.new(token: @token)
+  end
+end
+

--- a/app/validators/client_hold_status_validator.rb
+++ b/app/validators/client_hold_status_validator.rb
@@ -1,0 +1,41 @@
+class ClientHoldStatusValidator < BaseTaskValidator
+  def call
+    api = []
+    errors = []
+
+    domain_name = Mustache.render(@config['domain_template'].to_s, @attempt.vars)
+    if domain_name.blank?
+      errors << 'Domain name is missing'
+      return failure(api, errors)
+    end
+
+    info = with_audit(api, 'domain_info') { @service.domain_info(name: domain_name) }
+    if info.nil? || info[:success] == false
+      errors << 'Domain not found'
+      return failure(api, errors)
+    end
+
+    statuses = (info[:statuses] || {}).keys.map(&:to_s)
+    expect_absent = @config['expect_absent']
+    if expect_absent
+      if statuses.include?('clientHold')
+        errors << 'Domain still has clientHold status; remove it via the registrar portal'
+        return failure(api, errors)
+      end
+    else
+      unless statuses.include?('clientHold')
+        errors << 'Domain is not in clientHold status'
+        return failure(api, errors)
+      end
+    end
+
+    pass(api, { domain: info })
+  end
+
+  private
+
+  def api_service_adapter
+    DomainService.new(token: @token)
+  end
+end
+

--- a/app/validators/fix_broken_email_validator.rb
+++ b/app/validators/fix_broken_email_validator.rb
@@ -1,0 +1,69 @@
+class FixBrokenEmailValidator < BaseTaskValidator
+  def call
+    api = []
+    errors = []
+
+    domain_name = Mustache.render(@config['domain_template'].to_s, @attempt.vars)
+    if domain_name.blank?
+      errors << 'Domain name is missing'
+      return failure(api, errors)
+    end
+
+    info = with_audit(api, 'domain_info') { @service.domain_info(name: domain_name) }
+    if info.nil? || info[:success] == false
+      errors << 'Domain not found'
+      return failure(api, errors)
+    end
+
+    contact, contact_errors = load_registrant_contact(info, api)
+    errors.concat(contact_errors)
+
+    errors.concat(email_errors(contact))
+    errors.concat(status_errors(info))
+
+    return failure(api, errors) unless errors.empty?
+
+    pass(api, { domain: info, contact: contact })
+  end
+
+  private
+
+  def load_registrant_contact(domain_info, api)
+    code = domain_info.dig(:registrant, :code)
+    return [nil, ['Registrant code missing on domain']] if code.blank?
+
+    contact = with_audit(api, 'contact_info') do
+      ContactService.new(token: @token).contact_info(id: code)
+    end
+
+    return [contact, []] if contact && contact[:success] != false
+
+    [contact, ['Registrant contact not found']]
+  end
+
+  def email_errors(contact)
+    email = contact && contact[:email]
+    return ['Contact email missing'] if email.blank?
+
+    expected = @attempt.user&.email.to_s
+    return ['Current user email missing'] if expected.blank?
+
+    return [] if email.count('@') == 1 && !email.include?(' ') && email == expected
+
+    ['Broken domain is not fixed: registrant email must be updated to match your login email']
+  end
+
+  def status_errors(domain_info)
+    statuses = (domain_info[:statuses] || {}).keys.map(&:to_s)
+    prohibited = %w[forceDelete serverRenewProhibited serverTransferProhibited clientRenewProhibited clientTransferProhibited]
+
+    return [] if (statuses & prohibited).empty?
+
+    ['Broken domain is not fixed: force delete / renew / transfer restrictions are still present']
+  end
+
+  def api_service_adapter
+    DomainService.new(token: @token)
+  end
+end
+

--- a/app/validators/register_single_domain_validator.rb
+++ b/app/validators/register_single_domain_validator.rb
@@ -1,0 +1,95 @@
+class RegisterSingleDomainValidator < BaseTaskValidator
+  def call
+    api = []
+    errors = []
+
+    domain_name = Mustache.render(@config['domain_template'].to_s, @attempt.vars)
+    if domain_name.blank?
+      errors << 'Domain name is missing'
+      return failure(api, errors)
+    end
+
+    info = with_audit(api, 'domain_info') { @service.domain_info(name: domain_name) }
+    if info.nil? || info[:success] == false
+      errors << "Domain #{domain_name} not found"
+      Rails.logger.info "[RegisterSingleDomainValidator] domain=#{domain_name} domain_info failed: info=#{info.inspect}"
+      return failure(api, errors)
+    end
+
+    errors.concat(period_errors(info))
+    errors.concat(registrant_errors(info))
+
+    unless errors.empty?
+      Rails.logger.info "[RegisterSingleDomainValidator] domain=#{domain_name} errors=#{errors.inspect} info=#{info&.slice(:name, :expire_time, :created_at, :registrant)}"
+      return failure(api, errors)
+    end
+
+    pass(api, { domain: info })
+  end
+
+  private
+
+  def expected_period
+    @config['period'].to_s
+  end
+
+  def registrant_var
+    (@config['registrant_var'] || '').to_s
+  end
+
+  def period_errors(info)
+    return [] if expected_period.blank?
+
+    created = info[:created_at]
+    expected_expiry = calculate_expiry(created, expected_period)
+    return [] if info[:expire_time].present? && expected_expiry.present? &&
+                info[:expire_time].to_date == expected_expiry.to_date
+
+    ["Domain #{info[:name]} does not have expected period #{expected_period}"]
+  end
+
+  def registrant_errors(info)
+    return [] if registrant_var.blank?
+
+    expected_code = v(registrant_var)
+    actual_code = info.dig(:registrant, :code)
+    errors = []
+
+    errors << 'Domain registrant missing' if actual_code.blank?
+    if expected_code.present? && actual_code.present? && actual_code != expected_code
+      errors << 'Domain registrant does not match expected contact'
+    end
+
+    errors
+  end
+
+  def calculate_expiry(created, period)
+    return nil if created.blank? || period.blank?
+
+    value, unit = parse_period(period)
+    return nil unless value && unit
+
+    apply_period(created.to_date, value, unit)
+  end
+
+  def parse_period(period)
+    match = period.match(/\A(\d+)([ym])\z/i)
+    return [nil, nil] unless match
+
+    [match[1].to_i, match[2].downcase]
+  end
+
+  def apply_period(date, value, unit)
+    case unit
+    when 'y'
+      (date.advance(years: value) + 1.day).beginning_of_day
+    when 'm'
+      (date.advance(months: value) + 1.day).beginning_of_day
+    end
+  end
+
+  def api_service_adapter
+    DomainService.new(token: @token)
+  end
+end
+

--- a/app/validators/registrant_email_matches_user_validator.rb
+++ b/app/validators/registrant_email_matches_user_validator.rb
@@ -1,0 +1,53 @@
+class RegistrantEmailMatchesUserValidator < BaseTaskValidator
+  def call
+    api = []
+    errors = []
+
+    domain_name = Mustache.render(@config['domain_template'].to_s, @attempt.vars)
+    if domain_name.blank?
+      errors << 'Domain name is missing'
+      return failure(api, errors)
+    end
+
+    info = with_audit(api, 'domain_info') { @service.domain_info(name: domain_name) }
+    if info.nil? || info[:success] == false
+      errors << 'Domain not found'
+      return failure(api, errors)
+    end
+
+    contact, contact_errors = load_registrant_contact(info, api)
+    errors.concat(contact_errors)
+
+    return failure(api, errors) unless errors.empty?
+
+    email = contact[:email]
+    expected = @attempt.user&.email.to_s
+
+    if email.blank? || expected.blank? || email != expected
+      errors << 'Registrant email does not match current user email'
+      return failure(api, errors)
+    end
+
+    pass(api, { domain: info, contact: contact })
+  end
+
+  private
+
+  def load_registrant_contact(domain_info, api)
+    code = domain_info.dig(:registrant, :code)
+    return [nil, ['Registrant code missing on domain']] if code.blank?
+
+    contact = with_audit(api, 'contact_info') do
+      ContactService.new(token: @token).contact_info(id: code)
+    end
+
+    return [contact, []] if contact && contact[:success] != false
+
+    [contact, ['Registrant contact not found']]
+  end
+
+  def api_service_adapter
+    DomainService.new(token: @token)
+  end
+end
+

--- a/app/validators/renew_domain_validator.rb
+++ b/app/validators/renew_domain_validator.rb
@@ -51,15 +51,28 @@ class RenewDomainValidator < BaseTaskValidator
     return [I18n.t('validators.renew_domain_validator.domain_expire_time_missing', domain: name)] unless expire_time.present?
 
     expected_expiry = calculate_expiry(info[:created_at], years)
-    return [I18n.t('validators.renew_domain_validator.domain_not_renewed', domain: name)] unless expire_time.to_date == expected_expiry.to_date
+    return [I18n.t('validators.renew_domain_validator.domain_not_renewed', domain: name)] if expected_expiry.nil?
+
+    expire_date = date_from_value(expire_time)
+    expected_date = expected_expiry.respond_to?(:to_date) ? expected_expiry.to_date : expected_expiry
+    expire_str = expire_date&.to_s
+    expected_str = expected_date.respond_to?(:to_s) ? expected_date.to_s : expected_date.to_s
+    return [I18n.t('validators.renew_domain_validator.domain_not_renewed', domain: name)] unless expire_str == expected_str
 
     []
+  end
+
+  def date_from_value(value)
+    return value.to_date if value.respond_to?(:to_date) && !value.is_a?(String)
+    return Time.zone.parse(value.to_s).to_date if value.present?
+    nil
   end
 
   def calculate_expiry(created, years)
     return nil if created.nil? || years.nil?
 
-    (created.to_date.advance(years: years) + 1.day).beginning_of_day
+    base = created.respond_to?(:to_date) ? created.to_date : Time.zone.parse(created.to_s).to_date
+    base.advance(years: years).to_date + 1.day
   end
 
   def api_service_adapter

--- a/app/validators/single_contact_validator.rb
+++ b/app/validators/single_contact_validator.rb
@@ -1,0 +1,70 @@
+class SingleContactValidator < BaseTaskValidator
+  def call
+    id = @inputs[contact_input_key]
+    api = []
+    errors = []
+
+    contact = with_audit(api, 'contact_info') do
+      id.present? ? contact_service.contact_info(id: id) : nil
+    end
+
+    if contact.nil? || contact[:success] == false
+      errors << 'Contact not found'
+    else
+      errors.concat(type_errors(contact))
+      errors.concat(field_errors(contact))
+      errors.concat(recency_errors(contact))
+    end
+
+    return failure(api, errors) unless errors.empty?
+
+    pass(api, { contact: contact }, { contact_input_key => id })
+  end
+
+  private
+
+  def contact_input_key
+    (@config['input_key'] || 'contact_id').to_s
+  end
+
+  def expected_type
+    (@config['expected_type'] || '').to_s
+  end
+
+  def contact_service
+    @contact_service ||= ContactService.new(token: @token)
+  end
+
+  def type_errors(contact)
+    return [] if expected_type.blank?
+
+    contact_type = contact.dig(:ident, :type)
+    return [] if contact_type == expected_type
+
+    ["Contact type mismatch (expected #{expected_type})"]
+  end
+
+  def field_errors(contact)
+    required_keys = %i[code name ident phone email]
+    return [] if required_keys.all? { |k| contact[k].present? }
+
+    ['Required contact fields are missing']
+  end
+
+  def recency_errors(contact)
+    _window, cutoff = compute_window_and_cutoff
+    created_at = parse_time(contact[:created_at])
+    return [] if created_at && created_at >= cutoff
+
+    ['Contact is not recent enough']
+  end
+
+  def api_service_adapter
+    domain_service_placeholder
+  end
+
+  def domain_service_placeholder
+    DomainService.new(token: @token)
+  end
+end
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,7 @@
 #   end
 
 require_relative 'seeds/practical_tasks'
+require_relative 'seeds/practical_tasks_v2'
 require_relative 'seeds/theoretical_test_seeds'
 
 if User.where(role: :admin).empty?

--- a/db/seeds/practical_tasks_v2.rb
+++ b/db/seeds/practical_tasks_v2.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+puts "Creating practical test v2..."
+
+test_v2 = Test.find_or_create_by(slug: "practical-test-v2") do |t|
+  t.title_en = "Practical Test v2"
+  t.title_et = "Praktiline test v2"
+  t.test_type = :practical
+  t.time_limit_minutes = 120
+  t.passing_score_percentage = 100
+  t.active = true
+end
+
+puts "Creating practical tasks for v2..."
+
+tasks_v2 = [
+  {
+    display_order: 1,
+    title_en: "Create private person contact",
+    title_et: "Loo eraisikust kontakt",
+    body_en: "Create a private person contact for yourself that will be used for domain registration. Fill all required fields with correctly formatted data and indicate field types where applicable. Make sure the registrant email address is deliverable to you.",
+    body_et: "Loo enda jaoks eraisikust kontakt, mis on vajalik domeeni registreerimiseks. Kõik nõutud väljad tuleb täita õigel kujul ning vajadusel märgi väljade tüübid korrektselt. Veendu, et registreerija e-posti aadress oleks sulle kättesaadav.",
+    validator: {
+      klass: "SingleContactValidator",
+      config: {
+        expected_type: "priv",
+        input_key: "priv_contact_id",
+        window_minutes: 15
+      },
+      input_fields: [
+        { name: "priv_contact_id", label_en: "Private contact ID", label_et: "Eraisiku kontakti ID", required: true }
+      ],
+      depends_on_task_ids: []
+    }
+  },
+  {
+    display_order: 2,
+    title_en: "Register domain for private contact",
+    title_et: "Registreeri domeen eraisikule",
+    body_en: "Using the contact from Task 1, register the domain {{domain1}} for 1 year.",
+    body_et: "Kasuta 1. ülesandes loodud kontakti ja registreeri domeen {{domain1}} 1 aastaks.",
+    validator: {
+      klass: "RegisterSingleDomainValidator",
+      config: {
+        domain_template: "{{domain1}}",
+        period: "1y",
+        registrant_var: "priv_contact_id"
+      },
+      input_fields: [],
+      allocators: [
+        { name: "domain_pair", config: { use_faker: true } }
+      ],
+      depends_on_task_ids: [1]
+    }
+  },
+  {
+    display_order: 3,
+    title_en: "Create organization contact",
+    title_et: "Loo ettevõtte kontakt",
+    body_en: "Create an organization contact that will be used for domain registration. Fill all required fields with correctly formatted data and indicate field types where applicable. Make sure the registrant email address is deliverable to you.",
+    body_et: "Loo ettevõtte kontakt, mis on vajalik domeeni registreerimiseks. Kõik nõutud väljad tuleb täita õigel kujul ning vajadusel märgi väljade tüübid korrektselt. Veendu, et registreerija e-posti aadress oleks sulle kättesaadav.",
+    validator: {
+      klass: "SingleContactValidator",
+      config: {
+        expected_type: "org",
+        input_key: "org_contact_id",
+        window_minutes: 15
+      },
+      input_fields: [
+        { name: "org_contact_id", label_en: "Organization contact ID", label_et: "Ettevõtte kontakti ID", required: true }
+      ],
+      depends_on_task_ids: []
+    }
+  },
+  {
+    display_order: 4,
+    title_en: "Register domain for organization contact",
+    title_et: "Registreeri domeen ettevõttele",
+    body_en: "Using the organization contact from Task 3, register the domain {{domain2}} for 2 years.",
+    body_et: "Kasuta 3. ülesandes loodud ettevõtte kontakti ja registreeri domeen {{domain2}} 2 aastaks.",
+    validator: {
+      klass: "RegisterSingleDomainValidator",
+      config: {
+        domain_template: "{{domain2}}",
+        period: "2y",
+        registrant_var: "org_contact_id"
+      },
+      input_fields: [],
+      allocators: [],
+      depends_on_task_ids: [1, 3]
+    }
+  },
+  {
+    display_order: 5,
+    title_en: "Nameserver management",
+    title_et: "Nimeserveri haldus",
+    body_en: "Add/update nameservers of the domains created in the previous step.\nFor {{domain1}}: \n- Hostname {{ns1_1}}\nFor {{domain2}}:\n- Hostname {{ns2_1}}",
+    body_et: "Lisa/uuda nimeserverid domeenidele, mis on loodud eelmises sammos.\n{{domain1}}:\n- Hostname {{ns1_1}}\n{{domain2}}:\n- Hostname {{ns2_1}}",
+    validator: {
+      klass: "UpdateNameserversValidator",
+      config: {
+        nameservers: { "{{domain1}}": "{{ns1_1}}", "{{domain2}}": "{{ns2_1}}" }
+      },
+      input_fields: [],
+      allocators: [
+        { name: "nameservers", config: { count: 1, use_faker: true } }
+      ],
+      depends_on_task_ids: [2]
+    }
+  },
+  {
+    display_order: 6,
+    title_en: "Registrar change for two domains",
+    title_et: "Registripidaja muutus kahele domeenile",
+    body_en: "Transfer domains {{ xfer_domain1 }} and {{ xfer_domain2 }} from another registrar.\nTransfer codes:\n- {{ xfer_domain1 }}: {{ xfer_code1 }}\n- {{ xfer_domain2 }}: {{ xfer_code2 }}",
+    body_et: "Kanna domeenid {{ xfer_domain1 }} ja {{ xfer_domain2 }} teiselt registripidajalt üle.\nÜlekandekoodid:\n- {{ xfer_domain1 }}: {{ xfer_code1 }}\n- {{ xfer_domain2 }}: {{ xfer_code2 }}",
+    validator: {
+      klass: "TransferDomainsValidator",
+      config: {
+        domains: ["{{xfer_domain1}}", "{{xfer_domain2}}"]
+      },
+      input_fields: [],
+      allocators: [
+        { name: "domain_transfer_seed", config: { count: 2, use_faker: true } }
+      ],
+      depends_on_task_ids: []
+    }
+  },
+  {
+    display_order: 7,
+    title_en: "Domain renewal",
+    title_et: "Domeeni pikendamine",
+    body_en: "Renew domain {{domain1}} for 5 years.",
+    body_et: "Pikenda domeeni {{domain1}} 5 aastaks.",
+    validator: {
+      klass: "RenewDomainValidator",
+      config: { domain: "{{domain1}}", years: 6 },
+      input_fields: [],
+      allocators: [],
+      depends_on_task_ids: [2]
+    }
+  },
+  {
+    display_order: 8,
+    title_en: "Update registrant email on first transferred domain",
+    title_et: "Uuenda esimese ülekande-domeeni registreerija e-posti",
+    body_en: "Change the registrant email address of {{xfer_domain1}} so that it matches your own login email.",
+    body_et: "Muuda domeeni {{xfer_domain1}} registreerija e-posti nii, et see oleks sinu enda sisselogimise e-posti aadress ja oleks sulle kättesaadav.",
+    validator: {
+      klass: "RegistrantEmailMatchesUserValidator",
+      config: {
+        domain_template: "{{xfer_domain1}}"
+      },
+      input_fields: [],
+      allocators: [],
+      depends_on_task_ids: [6]
+    }
+  },
+  {
+    display_order: 9,
+    title_en: "Fix broken domain",
+    title_et: "Paranda katkine domeen",
+    body_en: "Fix the broken domain {{xfer_domain2}}. In the test environment you can see warnings that the registrant’s email address, although it looks syntactically correct, is not working and has caused domain restrictions to be applied. The domain currently has the following statuses: serverForceDelete, serverRenewProhibited and serverTransferProhibited.\n\nUpdate the registrant’s email address so that it matches your own login email and is deliverable to you. After the fix, these restrictions must be removed from the domain – it must no longer be in force delete state and renew/transfer restrictions must be cleared.",
+    body_et: "Paranda katkine domeen {{xfer_domain2}}. Testikeskkonnas näed selle domeeni juures hoiatust, et registreerija e‑posti aadress, kuigi visuaalselt korrektne, ei tööta ning domeenile on seetõttu lisatud piirangud. Domeenil on hetkel järgmised staatused: serverForceDelete, serverRenewProhibited ja serverTransferProhibited.\n\nUuenda registreerija e‑posti aadress selliseks, et see oleks sinu enda sisselogimise e‑posti aadress ja sulle reaalselt kättesaadav. Pärast parandamist peavad need piirangud domeenilt kaduma – domeen ei tohi enam olla force delete staatuses ning renew/transfer piirangud peavad olema eemaldatud.",
+    validator: {
+      klass: "FixBrokenEmailValidator",
+      config: {
+        domain_template: "{{xfer_domain2}}"
+      },
+      input_fields: [],
+      allocators: [],
+      depends_on_task_ids: [6]
+    }
+  },
+  {
+    display_order: 10,
+    title_en: "Align first transferred domain registrant with your domain",
+    title_et: "Joonda esimese ülekande-domeeni registreerija sinu domeeniga",
+    body_en: "Change the registrant of {{xfer_domain1}} so that it matches the registrant of {{domain1}} (the domain you registered in task 2).",
+    body_et: "Muuda domeeni {{xfer_domain1}} registreerija samaks domeeni {{domain1}} registreerijaga (domeen, mida registreerisid 2. ülesandes).",
+    validator: {
+      klass: "ChangeRegistrantValidator",
+      config: {
+        xfer_domain: "{{xfer_domain1}}",
+        source_domain: "{{domain1}}"
+      },
+      input_fields: [],
+      depends_on_task_ids: [2, 6]
+    }
+  },
+  {
+    display_order: 11,
+    title_en: "Registrant change without verified=yes",
+    title_et: "Registreerija vahetus ilma verified=yes",
+    body_en: "Change the registrant of {{xfer_domain1}} to match the registrant of {{domain1}} using email confirmation (without verified=yes).",
+    body_et: "Vaheta domeeni {{xfer_domain1}} registreerija samaks domeeni {{domain1}} registreerijaga, kasutades e-posti kinnitust (ilma verified=yes kasutamata).",
+    validator: {
+      klass: "ChangeRegistrantWithMethodValidator",
+      config: {
+        source_domain: "{{domain1}}",
+        target_domain: "{{xfer_domain1}}",
+        expected_method: "email_confirmation"
+      },
+      input_fields: [],
+      depends_on_task_ids: [2, 6]
+    }
+  },
+  {
+    display_order: 12,
+    title_en: "Registrant change with verified=yes",
+    title_et: "Registreerija vahetus verified=yes abil",
+    body_en: "Change the registrant of {{xfer_domain2}} to match the registrant of {{domain1}} using the verified=yes option.",
+    body_et: "Vaheta domeeni {{xfer_domain2}} registreerija samaks domeeni {{domain1}} registreerijaga, kasutades verified=yes valikut.",
+    validator: {
+      klass: "ChangeRegistrantWithMethodValidator",
+      config: {
+        source_domain: "{{domain1}}",
+        target_domain: "{{xfer_domain2}}",
+        expected_method: "verified"
+      },
+      input_fields: [],
+      depends_on_task_ids: [2, 6]
+    }
+  },
+  {
+    display_order: 13,
+    title_en: "Delete second transferred domain",
+    title_et: "Kustuta teine ülekande-domeen",
+    body_en: "Delete the domain {{xfer_domain2}} using the verified=yes option so that it immediately enters pendingDelete status.",
+    body_et: "Kustuta domeen {{xfer_domain2}}, kasutades verified=yes valikut, nii et see läheks kohe pendingDelete staatusesse.",
+    validator: {
+      klass: "DeleteDomainVerifiedValidator",
+      config: {
+        domain: "{{xfer_domain2}}"
+      },
+      input_fields: [],
+      depends_on_task_ids: [12]
+    }
+  },
+  {
+    display_order: 14,
+    title_en: "Add clientHold to first transferred domain",
+    title_et: "Lisa clientHold esimesele ülekande-domeenile",
+    body_en: "The domain {{xfer_domain1}} should have clientHold status. Add it using the XML console in the registrar portal (domain update, add client hold).",
+    body_et: "Domeenil {{xfer_domain1}} peab olema clientHold staatus. Lisa see registripidaja portaali XML konsooli kaudu (domeeni uuendus, add client hold).",
+    validator: {
+      klass: "ClientHoldStatusValidator",
+      config: {
+        domain_template: "{{xfer_domain1}}",
+        expect_absent: false
+      },
+      input_fields: [],
+      depends_on_task_ids: [11]
+    }
+  },
+  {
+    display_order: 15,
+    title_en: "Invoice generation",
+    title_et: "Arve loomine",
+    body_en: "Log into the test environment web portal and create a new invoice, then cancel it.",
+    body_et: "Logi testi keskkonna veebportaali, loo uus arve ja seejärel tühista see.",
+    validator: {
+      klass: "CreateAndCancelInvoiceValidator",
+      config: {
+        window_minutes: 15
+      },
+      input_fields: [],
+      depends_on_task_ids: []
+    }
+  }
+]
+
+tasks_v2.each do |task_data|
+  task = PracticalTask.find_or_initialize_by(
+    test_id: test_v2.id,
+    display_order: task_data[:display_order]
+  )
+
+  task.assign_attributes(
+    title_en: task_data[:title_en],
+    title_et: task_data[:title_et],
+    body_en: task_data[:body_en],
+    body_et: task_data[:body_et],
+    validator: task_data[:validator].to_json,
+    active: true
+  )
+
+  if task.save
+    puts "✓ Created/Updated v2: #{task.title_en}"
+  else
+    puts "✗ Failed v2: #{task.title_en} - #{task.errors.full_messages.join(', ')}"
+  end
+end
+
+task5 = test_v2.practical_tasks.find_by(display_order: 5)
+if task5
+  task5.update!(
+    body_en: "Add/update nameservers of the domains created in the previous step.\nFor {{domain1}}: \n- Hostname {{ns1_1}}\nFor {{domain2}}:\n- Hostname {{ns2_1}}",
+    body_et: "Lisa/uuda nimeserverid domeenidele, mis on loodud eelmises sammos.\n{{domain1}}:\n- Hostname {{ns1_1}}\n{{domain2}}:\n- Hostname {{ns2_1}}",
+    validator: {
+      klass: 'UpdateNameserversValidator',
+      config: { nameservers: { '{{domain1}}' => '{{ns1_1}}', '{{domain2}}' => '{{ns2_1}}' } },
+      input_fields: [],
+      allocators: [{ name: 'nameservers', config: { count: 1, use_faker: true } }],
+      depends_on_task_ids: [2]
+    }.to_json
+  )
+  puts "✓ Task 5 (nameserver management) body and validator fixed"
+end
+
+puts "Practical tasks v2 seeding completed!"
+

--- a/lib/tasks/test_attempts.rake
+++ b/lib/tasks/test_attempts.rake
@@ -1,9 +1,67 @@
 # frozen_string_literal: true
 
 namespace :test_attempts do
+  desc 'Fix task 5 (nameserver management) body and validator for practical-test-v2 so ns1_1/ns2_1 are shown'
+  task fix_task5_nameservers: :environment do
+    t = Test.find_by(slug: 'practical-test-v2')
+    task = t&.practical_tasks&.find_by(display_order: 5)
+    abort 'Task 5 not found' unless task
+    task.update!(
+      body_en: "Add/update nameservers of the domains created in the previous step.\nFor {{domain1}}: \n- Hostname {{ns1_1}}\nFor {{domain2}}:\n- Hostname {{ns2_1}}",
+      body_et: "Lisa/uuda nimeserverid domeenidele, mis on loodud eelmises sammos.\n{{domain1}}:\n- Hostname {{ns1_1}}\n{{domain2}}:\n- Hostname {{ns2_1}}",
+      validator: {
+        klass: 'UpdateNameserversValidator',
+        config: { nameservers: { '{{domain1}}' => '{{ns1_1}}', '{{domain2}}' => '{{ns2_1}}' } },
+        input_fields: [],
+        allocators: [{ name: 'nameservers', config: { count: 1, use_faker: true } }],
+        depends_on_task_ids: [2]
+      }.to_json
+    )
+    puts 'Task 5 (nameserver management) updated: body and validator now include ns1_1, ns2_1'
+  end
+
+  desc 'Set renewal task (display_order 7) to years: 6 for practical-test-v2'
+  task update_renewal_years: :environment do
+    t = Test.find_by(slug: 'practical-test-v2')
+    task = t&.practical_tasks&.find_by(display_order: 7)
+    abort 'Renewal task not found' unless task
+    v = task.validator.is_a?(String) ? JSON.parse(task.validator) : task.validator
+    v['config'] ||= {}
+    v['config']['years'] = 6
+    task.update_column(:validator, v.to_json)
+    puts 'Renewal task updated: years = 6'
+  end
+
   desc 'Purge detailed results older than 30 days (keeps completion time and pass/fail)'
   task purge_old_details: :environment do
     TestAttempt.purge_old_details!
     puts 'Purged detailed results older than 30 days'
+  end
+
+  desc 'Run renewal task validator for an attempt (local check without UI). Usage: rails test_attempts:validate_renewal[ACCESS_CODE] or rails test_attempts:validate_renewal[ACCESS_CODE,password]'
+  task :validate_renewal, [:access_code, :password] => :environment do |_t, args|
+    access_code = args[:access_code] || ENV['ACCESS_CODE']
+    password = args[:password] || ENV['VALIDATE_PASSWORD'] || 'password'
+    abort 'Give attempt access_code: rails test_attempts:validate_renewal[ACCESS_CODE]' if access_code.blank?
+
+    attempt = TestAttempt.find_by(access_code: access_code)
+    abort "Attempt with access_code #{access_code} not found" unless attempt
+
+    task = attempt.test.practical_tasks.active.ordered.find { |t| t.klass_name == 'RenewDomainValidator' }
+    abort 'Renewal task (RenewDomainValidator) not found for this test' unless task
+
+    token = ApiTokenService.new(username: attempt.user.username, password: password).generate
+    validator = RenewDomainValidator.new(attempt: attempt, config: task.conf, inputs: {}, token: token)
+    result = validator.call
+
+    if result[:passed]
+      puts 'OK: Renewal validation passed.'
+      puts "  domain: #{result[:evidence][:domain]}"
+    else
+      puts 'FAIL: Renewal validation failed.'
+      puts "  errors: #{result[:errors]&.join(', ')}"
+      puts "  api_audit: #{result[:api_audit]}" if result[:api_audit].present?
+    end
+    exit(result[:passed] ? 0 : 1)
   end
 end


### PR DESCRIPTION
Description:
This PR adds the practical test v2 flow and related validators, and applies a few fixes used in production.
New
db/seeds/practical_tasks_v2.rb – Defines 15 practical tasks (contacts, domain registration, nameservers, transfers, renewals, registrant changes, clientHold, delete, invoice). Task 14 asks the candidate to add clientHold to the first transferred domain (not remove it).
Validators for practical tasks:
SingleContactValidator – contact creation (priv/org)
RegisterSingleDomainValidator – single-domain registration
RegistrantEmailMatchesUserValidator – registrant email matches user
ChangeRegistrantValidator / ChangeRegistrantWithMethodValidator – registrant change, including verified vs email_confirmation
ClientHoldStatusValidator – clientHold present or absent
FixBrokenEmailValidator – fix broken domain (email + status restrictions)
db/seeds.rb – Loads practical_tasks_v2 so rails db:seed creates/updates v2 tasks.
lib/tasks/test_attempts.rake – Tasks for fixing task 5 nameservers, updating renewal years, purging old details, and validating renewal from the command line.
Changes
app/controllers/practical_tests_controller.rb – skip_before_action :verify_authenticity_token, only: :answer so validation still works after session/container changes (e.g. in dev).
app/validators/renew_domain_validator.rb – Expiry check made robust: handle nil and mixed types by comparing date strings instead of calling .to_date on possibly nil or non-Date values.